### PR TITLE
added configuration for second in-memory database

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,11 @@
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
 			<optional>true</optional>

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,0 +1,9 @@
+server.port=8082
+spring.h2.console.enabled=true
+
+spring.datasource.url=jdbc:h2:mem:cinemaTest
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=cinema
+spring.datasource.password=password
+
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,9 +4,6 @@ spring.datasource.url=jdbc:mysql://wwi21seb-group5cinema-database.mysql.database
 spring.datasource.username=cinema_db_user
 spring.datasource.password=5vLPr7ayO6TpqNF
 
-# comment next line out when pushing to production
-# spring.sql.init.mode=always
-
 spring.jpa.show-sql=true
 spring.jpa.hibernate.ddl-auto=create-drop
 spring.jpa.properties.hibernate.dialect =org.hibernate.dialect.MySQL8Dialect


### PR DESCRIPTION
## Describe your changes
Added in-memory H2 database for local development, since we don't want to use the azure db for this. 
This was achieved using spring profiles, the new profile for local development is 'dev', enable it by adding dev to the active profile parameter in the Runtime configuration of your IDE.

![image](https://user-images.githubusercontent.com/74607524/203262620-213d7429-9ccf-48ef-af56-064d7f249da7.png)

## Issue ticket number and link
no corresponding issue

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Documentation added?

